### PR TITLE
Bug fix. Don't need to send parameters to logout.

### DIFF
--- a/project/__init__.py
+++ b/project/__init__.py
@@ -101,7 +101,6 @@ def login():
 
 @app.route('/api/logout', methods=['GET'])
 def logout():
-    json_data = request.json
     session.pop('logged_in', None)
     return jsonify({'result' : True})
 


### PR DESCRIPTION
When calling logout, the api needed input in the form of json. 
This was not needed.
